### PR TITLE
fix Asteroid URL (with https)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Qondrite
 
-A QML wrapper for [Asteroid](http://github.com/modora/asteroid), a 
+A QML wrapper for [Asteroid](https://github.com/mondora/asteroid), a 
 javascript client (browser and node) for a Meteor backend.
 
 ##Table of contents


### PR DESCRIPTION
the Link to Asteroid is broken, as Github doesn't seem to accept http connections any more.
